### PR TITLE
Mwalsh/restore ad labels

### DIFF
--- a/addon/templates/components/nypr-a-ad-label.hbs
+++ b/addon/templates/components/nypr-a-ad-label.hbs
@@ -1,3 +1,3 @@
 {{!-- BEGIN-SNIPPET nypr-a-ad-label.hbs --}}
-{{!-- Advertisement --}}
+Advertisement
 {{!-- END-SNIPPET --}}

--- a/addon/templates/components/nypr-o-block-list-group/ad.hbs
+++ b/addon/templates/components/nypr-o-block-list-group/ad.hbs
@@ -1,3 +1,1 @@
 {{yield}}
-
-<NyprAAdLabel/>

--- a/addon/templates/components/nypr-o-header/leaderboard.hbs
+++ b/addon/templates/components/nypr-o-header/leaderboard.hbs
@@ -1,9 +1,5 @@
 {{!-- BEGIN-SNIPPET nypr-o-header-leaderboard.hbs --}}
 <div class="o-ad o-ad--leaderboard">
   {{yield}}
-
-  {{#unless @hideLabel}}
-    <NyprAAdLabel/>
-  {{/unless}}
 </div>
 {{!-- END-SNIPPET --}}


### PR DESCRIPTION
This brings back the text to the ad label now that we can hide them when dfp doesn't have an ad to serve us.

I'm also removing the  `NyprAAdLabel` from a few other templates. I don't think it should ever be standalone from an ad molecule.  Also I've been building components analogous to the ad molecules in the client for now. These use the NyprAAdLabel atom for their label but the ad part comes from nypr-ads. Thought a little bit about how those components could live here, but ultimately decided I don't want to introduce a dependency on `nypr-ads` into this repo right now.