### PR TITLE
Accessibility Nav roles and labels

### DIFF
--- a/addon/components/nypr-m-nav-read-more.js
+++ b/addon/components/nypr-m-nav-read-more.js
@@ -10,6 +10,8 @@ export default Component.extend({
   layout,
   tagName: 'nav',
   classNames: ['c-read-more-nav', 'u-breakout'],
+  attributeBindings: ['aria-label'],
+  'aria-label': 'Read More',
 
   /**
     List of items to render as links. Each item requires the following keys:

--- a/addon/components/nypr-m-secondary-nav.js
+++ b/addon/components/nypr-m-secondary-nav.js
@@ -11,9 +11,8 @@ export default Component.extend({
   tagName: 'nav',
   classNames: ['c-secondary-nav'],
 
-  attributeBindings: ['role', 'aria-label'],
-  role: 'navigation',
-  'aria-label': 'Secondary navigation',
+  attributeBindings: ['aria-label'],
+  'aria-label': 'Secondary',
 
   /**
     Navigation items objects with `url` and `title` keys.

--- a/addon/components/nypr-o-header/nav.js
+++ b/addon/components/nypr-o-header/nav.js
@@ -6,9 +6,7 @@ export default Component.extend({
   layout,
   tagName: 'nav',
   classNames: ['c-primary-nav'],
-  attributeBindings: ['role', 'aria-label'],
-
-  role: 'navigation',
-  'aria-label': 'Primary navigation',
+  attributeBindings: ['aria-label'],
+  'aria-label': 'Primary',
 });
 // END-SNIPPET


### PR DESCRIPTION
DS-291 
role="navigation" not needed when the tag name is nav 
aria-label for read more nav