### PR TITLE
DS-340 UTM in gallery shares

### DIFF
--- a/addon/components/nypr-m-share-tools/share.js
+++ b/addon/components/nypr-m-share-tools/share.js
@@ -73,12 +73,12 @@ export default Component.extend({
     if (this.utm) {
       let utmParams = Object.keys(this.utm).map(key => `utm_${key}=${this.utm[key]}`).join('&');
 
-      utmParams = encodeURIComponent(utmParams);
       if (url.indexOf('?') > -1) {
         url += `&${utmParams}`;
       } else {
         url += `?${utmParams}`;
       }
+      url = encodeURIComponent(url);
     }
 
     return `${shareBase}?${getParams(url, this.params)}`

--- a/addon/templates/components/nypr-o-gallery-overlay/slide.hbs
+++ b/addon/templates/components/nypr-o-gallery-overlay/slide.hbs
@@ -44,11 +44,13 @@
               @service='facebook'
               @url={{this.shareURL}}
               @ariaLabel="Share on Facebook"
+              @utm={{@share.facebook.utm}}
             />
             <tools.share
               @service='twitter'
               @url={{this.shareURL}}
               @ariaLabel="Share on Twitter"
+              @utm={{@share.twitter.utm}}
               @params={{hash
                 text=@share.twitter.text
                 via=@share.twitter.via
@@ -57,6 +59,7 @@
               @service='reddit'
               @url={{this.shareURL}}
               @ariaLabel="Share on Reddit"
+              @utm={{@share.reddit.utm}}
               @params={{hash
                 title=@share.reddit.title
             }}/>
@@ -64,6 +67,7 @@
               @service='email'
               @url={{this.shareURL}}
               @ariaLabel="Share via email"
+              @utm={{@share.email.utm}}
               @params={{hash
                 subject=@share.email.subject
                 body=@share.email.body


### PR DESCRIPTION
https://jira.wnyc.org/browse/DS-340

- pass UTM variables in share metadata from the slide to the share tools
- Change how url encoding works for UTM variables
  - Before, UTM variables were encoded individually as part of the link
  - In urls that open share pages, the site link itself is a parameter (eg `url=site%20link`) so we should encode the whole link including things like `&` and `?`
  - I checked prod, and the old way still seemed to work (maybe the sharing page handles it) but i ran into problems when the url contained additional parameters (e.g. `image=1`)