### PR TITLE
support srcset in gallery lead thumbnails

### DIFF
--- a/addon/templates/components/nypr-m-gallery-lead.hbs
+++ b/addon/templates/components/nypr-m-gallery-lead.hbs
@@ -3,7 +3,7 @@
 
   <NyprMFigure as |figure|>
     <figure.image
-      @srcS={{this.currentSlide.full}}
+      @srcS={{this.currentSlide.preview}}
       onclick={{action 'goToSlide'}}
       data-test-gallery-current
     />

--- a/addon/templates/components/nypr-m-gallery-lead.hbs
+++ b/addon/templates/components/nypr-m-gallery-lead.hbs
@@ -29,7 +29,7 @@
   {{#each @slides as |slide i|}}
     {{#if (lt i 4)}}
       <button {{action 'setCurrent' i}} class="c-lead-gallery__thumbs-thumb {{if (eq this.currentIndex i) 'is-active'}}" data-test-gallery-thumb={{i}}>
-        <img src={{slide.thumb}} alt={{slide.caption}}>
+        <img src={{slide.thumb}} srcset={{slide.thumbSrcSet}} alt={{slide.caption}}>
       </button>
     {{/if}}
   {{/each}}

--- a/addon/templates/components/nypr-m-gallery-lead.hbs
+++ b/addon/templates/components/nypr-m-gallery-lead.hbs
@@ -4,7 +4,6 @@
   <NyprMFigure as |figure|>
     <figure.image
       @srcS={{this.currentSlide.full}}
-      @ratio='3x2'
       onclick={{action 'goToSlide'}}
       data-test-gallery-current
     />

--- a/tests/integration/components/nypr-m-gallery-lead-test.js
+++ b/tests/integration/components/nypr-m-gallery-lead-test.js
@@ -7,22 +7,26 @@ import test from 'ember-sinon-qunit/test-support/test';
 const GALLERY = [{
   caption: 'This is a slide caption',
   credit: 'Getty',
-  src: 'https://picsum.photos/600/300?random',
-  full: 'https://picsum.photos/600/300?random',
+  thumb: 'https://picsum.photos/100/100?random',
+  preview: 'https://picsum.photos/600/300?random',
+  full: 'https://picsum.photos/600/600?random',
   title: 'This is what a slide title looks like',
 }, {
   caption: 'This is a slide only a caption; no title or credit',
-  src: 'https://picsum.photos/600/300?random=1',
-  full: 'https://picsum.photos/600/300?random=1',
+  thumb: 'https://picsum.photos/100/100?random=1',
+  preview: 'https://picsum.photos/600/300?random=1',
+  full: 'https://picsum.photos/600/600?random=1',
 }, {
   title: 'This is a slide with only a title',
-  src: 'https://picsum.photos/600/300?random=2',
-  full: 'https://picsum.photos/600/300?random=2',
+  thumb: 'https://picsum.photos/100/100?random=2',
+  preview: 'https://picsum.photos/600/300?random=2',
+  full: 'https://picsum.photos/600/600?random=2',
 }, {
   caption: 'This is a slide with no title; just caption & credit',
   credit: 'Foo Bar/AP News',
-  src: 'https://picsum.photos/600/300?random=3',
-  full: 'https://picsum.photos/600/300?random=3',
+  thumb: 'https://picsum.photos/100/100?random=3',
+  preview: 'https://picsum.photos/600/300?random=3',
+  full: 'https://picsum.photos/600/600?random=3',
 }];
 
 module('Integration | Component | nypr-m-gallery-lead', function(hooks) {
@@ -35,11 +39,11 @@ module('Integration | Component | nypr-m-gallery-lead', function(hooks) {
 
     assert.dom('.c-lead-gallery').exists();
     assert.dom('.c-lead-gallery__thumbs-thumb').exists({count: GALLERY.length + 1}, 'one thumbnail for each image plus the "view all" button');
-    assert.dom('figure.o-figure img').hasAttribute('src', GALLERY[0].src);
+    assert.dom('figure.o-figure img').hasAttribute('src', GALLERY[0].preview);
     assert.dom('.c-lead-gallery__thumbs-thumb-text').hasText(`View all ${GALLERY.length}`);
 
     await click('[data-test-gallery-thumb="1"]');
-    assert.dom('figure.o-figure img').hasAttribute('src', GALLERY[1].src, 'it changes the active slide when clicking a thumbnail');
+    assert.dom('figure.o-figure img').hasAttribute('src', GALLERY[1].preview, 'it changes the active slide when clicking a thumbnail');
 
     await click('[data-test-gallery-current]');
   });


### PR DESCRIPTION
part of nypublicradio/gothamist-web-client#48