### PR TITLE
add 3d heading to contact out

### DIFF
--- a/addon/components/nypr-o-contact.js
+++ b/addon/components/nypr-o-contact.js
@@ -17,7 +17,7 @@ import layout from '../templates/components/nypr-o-contact';
 */
 export default Component.extend({
   layout,
-  classNames: ['c-contact-tout', 'o-rte-text', 'u-reversed-out'],
+  classNames: ['c-contact-tout', 'o-rte-text', 'u-reversed-out', 'o-3d-heading'],
 
   /**
     Text content


### PR DESCRIPTION
compat for nypublicradio/pattern-lab#68, which removes the black border around images