### PR TITLE
Deploying radial to a static S3 site

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,1 @@
+import '@panosvoudouris/addon-versions/register';

--- a/.storybook/storybook-config.json
+++ b/.storybook/storybook-config.json
@@ -1,0 +1,13 @@
+{
+  "storybook": {
+    "versions": {
+      "availableVersions": [
+        "latest",
+        "0.0.1"
+      ],
+      "hostname": "localhost:8080",
+      "localhost": "localhost:8080",
+      "regex": "\/([^\/]+?)\/?$"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ To run Storybook locally you need Ember to already be running (`ember serve`) or
 yarn storybook
 ```
 
+## Deployment
+Radial is deployed as a static site which is housed in an S3 Bucket behind a Cloudfront Distribution.
+
+### Production/Staging Environments
+We use the `addon-versions` addon to maintain a single environment for both production and staging. This addon allows us to use the underlying directory structure of the S3 bucket as separate versions of the site. Each "version" that is deployed to the S3 bucket is stored in its own directory (as seen in the snippet from `circle.yml` below). 
+```bash
+[[ $CIRCLE_BRANCH = "master" ]] && RELEASE="latest" || { [[ -n $CIRCLE_BRANCH ]] && RELEASE=$CIRCLE_BRANCH || RELEASE=$CIRCLE_TAG; }
+yarn storybook-to-aws-s3 --bucket-path=$S3_BUCKET/$RELEASE -e=./storybook-static/$RELEASE
+aws s3 cp storybook-static/index.html s3://$S3_BUCKET
+aws s3 cp storybook-static/storybook-config.json s3://$S3_BUCKET
+AWS_PAGER="" aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/index.html" "/storybook-config.json" "/$RELEASE/*"
+```
+
+Then `addon-versions` displays a "Versions" tab in the Storybook UI that allows the user to toggle between different available versions. This addon doesn't automatically detect the underlying directory structure, it relies on the `available-versions` field in `storybook-config.json` to populate its buttons.
+
+> :warning: Thus, when deploying Radial, you must add a line to the `available-versions` field :warning:
+
+### QA Branches
+All branches that begin with `qa/` will be deployed to the S3 bucket. You have the option of adding your branch to the `available-versions` field or you can just modify the url manually to view your work.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/circle.yml
+++ b/circle.yml
@@ -72,27 +72,6 @@ jobs:
           paths:
             - storybook-static
 
-  deploy-storybook:
-    <<: *defaults
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Disable jekyll builds
-          command: touch storybook-static/.nojekyll
-      - run:
-          name: Configure git user
-          command: |
-            git config user.email "ci-build@nypublicradio.org"
-            git config user.name "ci-build"
-      - add_ssh_keys:
-          fingerprints:
-            - "ab:f0:e6:36:b3:6d:67:77:fe:fc:b3:22:23:59:a2:c6"
-      - run:
-          name: Deploy docs to gh-pages branch
-          command: npx gh-pages --dotfiles --message "[skip ci] Publish Docs" --dist storybook-static
-
 
   deploy-storybook-to-s3:
     <<: *defaults
@@ -135,30 +114,22 @@ workflows:
           requires:
             - install
 
-  deploy-storybook:
+  deploy-storybook-to-s3:
     jobs:
       - install:
           filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+/
             branches:
-              only: master
+              only:
+                - master
+                - /qa\/.*/
       - test:
           requires:
             - install
       - build-storybook:
           requires:
             - test
-      - deploy-storybook:
-          requires: 
-            - build-storybook
-  deploy-storybook-to-s3:
-    jobs:
-      - install:
-          filters:
-            branches:
-              only: nc/storybook
-      - build-storybook:
-          requires:
-            - install
       - deploy-storybook-to-s3:
           requires:
             - build-storybook

--- a/circle.yml
+++ b/circle.yml
@@ -63,7 +63,10 @@ jobs:
           command: npx ember build
       - run:
           name: Build Docs
-          command: npm run build-storybook
+          command: |
+            [[ $CIRCLE_BRANCH = "master" ]] && RELEASE="latest" || { [[ -n $CIRCLE_BRANCH ]] && RELEASE=$CIRCLE_BRANCH || RELEASE=$CIRCLE_TAG; }
+            npm run build-storybook -- -o storybook-static/$RELEASE
+            cp index.html storybook-config.json storybook-static/
       - persist_to_workspace:
           root: .
           paths:
@@ -90,6 +93,36 @@ jobs:
           name: Deploy docs to gh-pages branch
           command: npx gh-pages --dotfiles --message "[skip ci] Publish Docs" --dist storybook-static
 
+
+  deploy-storybook-to-s3:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *restore_node
+      - attach_workspace:
+          at: .
+      - run:
+          name: Disable jekyll builds
+          command: touch storybook-static/.nojekyll
+      - run:
+          name: Install AWSCLI
+          command: |
+            sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            sudo unzip awscliv2.zip
+            sudo ./aws/install
+            aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+            aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+            aws configure set default.region $AWS_DEFAULT_REGION
+
+      - run:
+          name: Deploy docs to aws s3
+          command: |
+            [[ $CIRCLE_BRANCH = "master" ]] && RELEASE="latest" || { [[ -n $CIRCLE_BRANCH ]] && RELEASE=$CIRCLE_BRANCH || RELEASE=$CIRCLE_TAG; }
+            yarn storybook-to-aws-s3 --bucket-path=$S3_BUCKET/$RELEASE -e=./storybook-static/$RELEASE
+            aws s3 cp storybook-static/index.html s3://$S3_BUCKET
+            aws s3 cp storybook-static/storybook-config.json s3://$S3_BUCKET
+            AWS_PAGER="" aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/index.html" "/storybook-config.json" "/$RELEASE/*"
+
 workflows:
   version: 2
   just-test:
@@ -115,5 +148,17 @@ workflows:
           requires:
             - test
       - deploy-storybook:
+          requires: 
+            - build-storybook
+  deploy-storybook-to-s3:
+    jobs:
+      - install:
+          filters:
+            branches:
+              only: nc/storybook
+      - build-storybook:
+          requires:
+            - install
+      - deploy-storybook-to-s3:
           requires:
             - build-storybook

--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+   <head>
+      <title>NYPR Design System</title>
+      <meta http-equiv = "refresh" content = "0; url = https://nypr-design-system.nypr.digital/latest/index.html" />
+   </head>
+   <body></body>
+</html>

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "test": "ember test",
     "test:all": "ember try:each",
     "storybook": "start-storybook -p 6006 -s dist,stories/assets",
-    "build-storybook": "build-storybook -s dist,stories/assets -o storybook-static"
+    "build-storybook": "build-storybook -s dist,stories/assets",
+    "deploy-storybook": "storybook-to-aws-s3"
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@panosvoudouris/addon-versions": "^1.0.1",
     "broccoli-merge-files": "^0.8.0",
     "ember-auto-import": "^1.2.19",
     "ember-basic-dropdown": "^1.1.2",
@@ -54,6 +56,8 @@
     "@storybook/addon-viewport": "^5.3.17",
     "@storybook/addons": "5.3.9",
     "@storybook/ember": "5.3.9",
+    "@storybook/ember-cli-storybook": "storybookjs/ember-cli-storybook#master",
+    "@storybook/storybook-deployer": "^2.8.3",
     "@types/ember": "^3.0.27",
     "babel-loader": "^8.0.6",
     "broccoli-asset-rev": "^2.7.0",

--- a/stories/10-For Developers/Setting up Your Environment.stories.mdx
+++ b/stories/10-For Developers/Setting up Your Environment.stories.mdx
@@ -4,36 +4,41 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Setting Up your Environment For Local Development
 
-1. Clone the repo
+### Clone the repo
 
-```git clone git@github.com:nypublicradio/nypr-design-system.git```
+```bash
+git clone git@github.com:nypublicradio/nypr-design-system.git
+cd nypr-design-system
+```
 
-```cd nypr-design-system```
-
-2. Checkout the radial branch
-
-```git checkout radial```
-
+### Checkout the radial branch
+```bash
+git checkout radial
+```
 (Temporary step until this is all merged into master)
 
-3. Install dependencies
+### Install dependencies
+```bash
+yarn
+```
 
-```yarn```
+> :warning: NOTE: You may need to install watchman if your dev environment doesn't have it already 
 
-4. Install watchman if the project doesn't have it already 
+```bash
+brew install watchman
+``` 
 
-```brew install watchman``` 
-
-5. Start ember
-
-```ember serve```
+### Start ember
+```bash
+ember serve
+```
 
 (*Storybook looks at the `/dist/` folder to find your ember components. If you're only working on documentation and not modifying ember components, you should be able to get away with only running `ember build`, but if you make any changes to ember code they won't be reflected in storybook until you build again.)
 
-6. Run storybook
-
+### Run storybook
 While ember is still running:
-
-```yarn storybook```
+```bash
+yarn storybook
+```
 
 Storybook will open automatically in your browser. You can now edit your components and stories and see the changes live.

--- a/storybook-config.json
+++ b/storybook-config.json
@@ -1,0 +1,14 @@
+{
+  "storybook": {
+    "versions": {
+      "availableVersions": [
+        "latest",
+        "nc/storybook",
+        "0.0.1"
+      ],
+      "hostname": "nypr-design-system.nypr.digital",
+      "localhost": "nypr-design-system.nypr.digital",
+      "regex": "\/(.*)\/index[.]html$"
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,6 +1359,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@panosvoudouris/addon-versions@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@panosvoudouris/addon-versions/-/addon-versions-1.0.1.tgz#b8dad7e218025b1308465d71d5e2ba564fb9eeb3"
+  integrity sha512-C9FJM1w+xyPNNHIHGFmXiJUbS3WM2X9nxNUoDabVREbck5gvkxlizzf24NAGyXu1Loicd761wSwKVuI6V+unFg==
+
 "@reach/router@^1.2.1":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.3.tgz#58162860dce6c9449d49be86b0561b5ef46d80db"
@@ -1875,6 +1880,15 @@
   dependencies:
     lodash "^4.17.15"
 
+"@storybook/ember-cli-storybook@storybookjs/ember-cli-storybook#master":
+  version "0.2.1"
+  resolved "https://codeload.github.com/storybookjs/ember-cli-storybook/tar.gz/94fdd83182436e804bc54556d6cd9573faab044e"
+  dependencies:
+    broccoli-funnel "^2.0.2"
+    cheerio "^1.0.0-rc.2"
+    ember-cli-addon-docs-yuidoc "^0.2.3"
+    ember-cli-babel "^7.1.2"
+
 "@storybook/ember@5.3.9":
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/@storybook/ember/-/ember-5.3.9.tgz#fa34d6ba060f9339a04d09d3cc304ca57b3e22ad"
@@ -1951,6 +1965,17 @@
     prettier "^1.16.4"
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.3"
+
+"@storybook/storybook-deployer@^2.8.3":
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.5.tgz#078a8855883b9458686b6870aca957af907c4de7"
+  integrity sha512-3fR+8+rSNjRkaHElba067o8sp2OHAqcBgic5sC44rkjfsw31I6ccz94MLLel34/ae009QPMgY1h892Ddfs3SUA==
+  dependencies:
+    git-url-parse "^11.1.2"
+    glob "^7.1.3"
+    parse-repo "^1.0.4"
+    shelljs "^0.8.1"
+    yargs "^11.0.0"
 
 "@storybook/theming@5.3.17":
   version "5.3.17"
@@ -5360,6 +5385,11 @@ camelcase@^1.0.2:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
   integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
 camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -5697,6 +5727,15 @@ cliui@^2.1.0:
     center-align "^0.1.1"
     right-align "^0.1.1"
     wordwrap "0.0.2"
+
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
 
 clone-response@1.0.2:
   version "1.0.2"
@@ -6345,7 +6384,7 @@ debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.0.0:
+decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -8898,6 +8937,11 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
   integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
+get-caller-file@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -8985,6 +9029,21 @@ git-transport-protocol@^0.1.0:
     git-read-pkt-line "0.0.8"
     git-write-pkt-line "0.1.0"
     through "~2.2.7"
+
+git-up@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
+  integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
+  dependencies:
+    is-ssh "^1.3.0"
+    parse-url "^5.0.0"
+
+git-url-parse@^11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.1.2.tgz#aff1a897c36cc93699270587bea3dbcbbb95de67"
+  integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
+  dependencies:
+    git-up "^4.0.0"
 
 git-write-pkt-line@0.1.0:
   version "0.1.0"
@@ -9955,6 +10014,11 @@ invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -10285,6 +10349,13 @@ is-set@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.1.tgz#d1604afdab1724986d30091575f54945da7e5f43"
   integrity sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==
+
+is-ssh@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.1.tgz#f349a8cadd24e65298037a522cf7520f2e81a0f3"
+  integrity sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==
+  dependencies:
+    protocols "^1.1.0"
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
@@ -10847,6 +10918,13 @@ lazy-universal-dotenv@^3.0.1:
     dotenv "^8.0.0"
     dotenv-expand "^5.1.0"
 
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
+
 leek@0.0.24:
   version "0.0.24"
   resolved "https://registry.yarnpkg.com/leek/-/leek-0.0.24.tgz#e400e57f0e60d8ef2bd4d068dc428a54345dbcda"
@@ -11278,6 +11356,13 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -11430,6 +11515,15 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+mem@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
 
 memoize-one@^5.0.0:
   version "5.1.1"
@@ -11588,7 +11682,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.1.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -11969,6 +12063,11 @@ normalize-url@2.0.1:
     query-string "^5.0.1"
     sort-keys "^2.0.0"
 
+normalize-url@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
+  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+
 npm-package-arg@^6.1.0:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.1.tgz#02168cb0a49a2b75bf988a28698de7b529df5cb7"
@@ -12238,6 +12337,15 @@ os-homedir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
+os-locale@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -12255,6 +12363,11 @@ p-cancelable@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
   integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
+
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
 p-event@^2.3.1:
   version "2.3.1"
@@ -12277,6 +12390,11 @@ p-is-promise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
   integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
+
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -12427,6 +12545,29 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
+
+parse-path@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.1.tgz#0ec769704949778cb3b8eda5e994c32073a1adff"
+  integrity sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
+
+parse-repo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
+  integrity sha1-dLkdLLhnXRG5mXagBl9s4X+hvMg=
+
+parse-url@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
+  integrity sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==
+  dependencies:
+    is-ssh "^1.3.0"
+    normalize-url "^3.3.0"
+    parse-path "^4.0.0"
+    protocols "^1.4.0"
 
 parse5@5.1.0:
   version "5.1.0"
@@ -12900,6 +13041,11 @@ property-information@^5.0.0, property-information@^5.3.0:
   integrity sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==
   dependencies:
     xtend "^4.0.0"
+
+protocols@^1.1.0, protocols@^1.4.0:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
+  integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
 
 proxy-addr@~2.0.5:
   version "2.0.6"
@@ -13904,6 +14050,16 @@ request@~2.40.0:
     tough-cookie ">=0.12.0"
     tunnel-agent "~0.4.0"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-main-filename@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+  integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -14325,7 +14481,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@~2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -14402,7 +14558,7 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.3:
+shelljs@^0.8.1, shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
@@ -14911,7 +15067,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.1.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -16363,6 +16519,11 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
 which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -16448,6 +16609,14 @@ workerpool@^3.1.1:
     "@babel/core" "^7.3.4"
     object-assign "4.1.1"
     rsvp "^4.8.4"
+
+wrap-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -16535,6 +16704,11 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+y18n@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
 y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
@@ -16569,6 +16743,31 @@ yaml@^1.7.2:
   integrity sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==
   dependencies:
     "@babel/runtime" "^7.8.7"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.1.tgz#5052efe3446a4df5ed669c995886cc0f13702766"
+  integrity sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
So most of the work that needs to be reviewed here is more conceptual. As it stands, all of this code works and deploys to the host: https://nypr-design-system.nypr.digital/

There are two files that are used in prod only and need to be managed manually if something needs to change with them. These files are `index.html` and `storybook-config.json`. The former is a simple redirect that I put in place to handle the case of someone going to the base host instead of the versioned path in the url (e.g. https://nypr-design-system.nypr.digital/ vs https://nypr-design-system.nypr.digital/latest/index.html). The latter is used to mange the available versions listed by the version addon, and also sets up the regex which is used to swap between versions by changing the URL when you click the version buttons. In the future, I'd like to make the generation of this file automated, but I think that's a larger undertaking that will grow the scope of this ticket too much.

There is some work not shown in this PR - the S3 object lifecycle rules. We use these to basically say that anything in the directory `qa` within the S3 bucket should only exist for a week. This prevents old QA branches from piling up.

After this branch is merged into Radial, there will need to be a couple of pieces of cleanup done.
1. Modify `storybook-config.json` to remove `nc/storybook` as an available version.
2. Modify `circle.yml` to not deploy to GHPages anymore.