### PR TITLE
DS-649 attempt to fix donate border button color on demo

### DIFF
--- a/app/styles/_library/_objects.buttons.scss
+++ b/app/styles/_library/_objects.buttons.scss
@@ -45,6 +45,7 @@ input[type="submit"] {
   width: 100%;
   height: 100%;
   border: 3px solid rgb(var(--color-primary-2));
+  border-color: rgb(var(--color-primary-2));
   transform: translate(0, 0);
   transition: var(--animation-easing-incoming) var(--animation-duration-standard);// used to be $hard-ease-in
 }


### PR DESCRIPTION
This ticket fixes the `DONATE` button border color on demo (and down the road in production), where it was white. I missed this the first time around because the border color was correct in my local development environment. It appears that the sass compiler dropped the color, resulting in `border: 3px solid;`. To fix, I added the more specific `border-color` attribute.

The optimal solution would be to figure out why the color was dropped in the first place. My guess that it is a compression action by the sass compiler gone awry.