### PR TITLE
Max width allows all nav items to display in one horizontal line

### DIFF
--- a/app/styles/_library/_module.footer.scss
+++ b/app/styles/_library/_module.footer.scss
@@ -21,7 +21,7 @@
 
 .c-main-footer__col1 {
   width: 100%;
-  max-width: 549px;
+  max-width: 570px;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
`max-width` now matches live/old Gothamist (`570px`)