### PR TITLE
DS-797 Update font on product marketing banner

### DIFF
--- a/app/styles/_library/_objects.messaging.scss
+++ b/app/styles/_library/_objects.messaging.scss
@@ -39,11 +39,10 @@
 }
 
 .o-box-banner__title {
-  font-weight: bold;
-  font-size: var(--font-size-8);
+  @include typeface(header, 8);
 
   @include media(">large") {
-    font-size: var(--font-size-10);
+    @include typeface(header, 10);
     text-align: right;
   }
 }


### PR DESCRIPTION
The title should use the header font, (pragati narrow on gothamist)