### PR TITLE
Klarocca/whitelabel overrides

### DIFF
--- a/addon/components/nypr-m-brands-linkroll.js
+++ b/addon/components/nypr-m-brands-linkroll.js
@@ -18,7 +18,7 @@ const NAV_ITEMS = [{
   url: 'https://gothamist.com',
   title: 'Gothamist',
 }, {
-  url: 'https://www.njpr.org',
+  url: 'http://njpublicradio.org',
   title: 'NJPR',
 }, {
   url: 'https://www.wnycstudios.org',

--- a/app/styles/_library/_base.links.scss
+++ b/app/styles/_library/_base.links.scss
@@ -64,9 +64,13 @@ a > span {
   border-bottom-color: rgb(var(--color-link));
 }
 
+.u-has-accent--secondary path {
+  transition: var(--animation-duration-fast);
+}
+
 .u-has-accent--secondary:hover path,
 .o-rte-text .u-has-accent--secondary:hover path {
-  fill: rgb(var(--color-background));
+  fill: rgb(var(--color-link-hover));
 }
 
 .u-has-accent-inline {

--- a/app/styles/_library/_base.text.scss
+++ b/app/styles/_library/_base.text.scss
@@ -29,7 +29,6 @@ b {
  */
 blockquote {
   margin-left: var(--space-5);
-  @include border-accent(bottom, left);
 }
 blockquote p {
     margin: var(--space-5) 0;

--- a/app/styles/_library/_module.article.scss
+++ b/app/styles/_library/_module.article.scss
@@ -7,10 +7,10 @@
 }
 
 .c-article__headline {
-  @include typeface(header, 14);
+  @include typeface(header, 13);
 
   @include media(">medium") {
-    @include typeface(header, 16);
+    @include typeface(header, 13);
   }
 }
 

--- a/app/styles/_library/_module.footer.scss
+++ b/app/styles/_library/_module.footer.scss
@@ -213,8 +213,7 @@
 }
 
 .c-main-footer__terms-links a:hover {
-  background-color: rgb(var(--color-primary-2));
-  color: rgb(var(--color-link-hover-2));
+  color: rgb(var(--color-link-hover));
 }
 
 // view all brands

--- a/app/styles/_library/_module.footer.scss
+++ b/app/styles/_library/_module.footer.scss
@@ -10,6 +10,18 @@
   color: rgb(var(--color-footer-text));
 }
 
+.c-main-footer a,
+.c-main-footer a:visited,
+.c-main-footer a:active {
+  color: rgb(var(--color-footer-link));
+  text-decoration: none;
+
+  &:hover {
+    color: rgb(var(--color-footer-link));
+    text-decoration: none;
+  }
+}
+
 .c-main-footer__inner {
   @include media(">xlarge") {
     margin-top: 0;

--- a/app/styles/_library/_module.gallery.scss
+++ b/app/styles/_library/_module.gallery.scss
@@ -32,6 +32,20 @@
   }
 }
 
+.c-gallery-overlay .o-back-to-link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+.c-gallery-overlay .u-has-accent:hover,
+.c-gallery-overlay .o-rte-text .u-has-accent:hover {
+  background-color: transparent;
+  opacity: var(--opacity-hover);
+}
+
 .c-slides {
   display: flex;
   flex-wrap: wrap;

--- a/app/styles/_library/_module.gallery.scss
+++ b/app/styles/_library/_module.gallery.scss
@@ -14,8 +14,7 @@
 }
 
 .c-gallery-overlay .o-credit a:hover {
-  color: rgb(var(--color-gallery-link));
-  background-color: rgb(var(--color-gallery-link-hover));
+  opacity: var(--opacity-hover);
 }
 
 .c-gallery-overlay .o-rte-text a:visited {

--- a/app/styles/_library/_module.header.scss
+++ b/app/styles/_library/_module.header.scss
@@ -96,6 +96,7 @@
 }
 
 .c-main-header__donate.o-button {
+  font-size: var(--font-size-5);
   background-color: rgb(var(--color-header-button-background));
   color: rgb(var(--color-header-button-text));
 
@@ -171,7 +172,7 @@
 }
 
 .c-main-header__share .c-share-tools__link:hover path {
-  fill: rgb(var(--color-header-icon-hover));
+  fill: rgb(var(--color-navigation-link-hover));
 }
 
 .c-main-header__share .c-share-tools__link path {
@@ -299,6 +300,11 @@
 
 .c-side-menu .c-menu-toggle + * {
   margin-left: 0;
+}
+
+.c-side-menu .c-search__button:hover {
+  background-color: rgb(var(--color-button-primary));
+  opacity: var(--opacity-hover);
 }
 
 .c-side-menu__group {

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -96,7 +96,7 @@
  * Urgent block banner
  */
 .c-block--urgent .c-block__eyebrow > .o-kicker {
-  background-color: rgb(var(--color-text-inverse));
+  background: rgb(var(--color-background));
   color: rgb(var(--color-text-inverse));
 }
 
@@ -298,6 +298,7 @@ $author-media-width-l: 360;
   text-decoration: none;
 
   &:hover {
+    color: rgb(var(--color-link-hover));
     text-decoration: none;
   }
 }

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -146,7 +146,7 @@
 }
 
 .c-block--horizontal .c-block__title {
-  @include typeface(header, 8);
+  @include typeface(header, 7);
 }
 
 .c-block--horizontal .c-block__object {

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -10,6 +10,7 @@
   text-align: right;
 }
 
+.c-block__object .c-block__title-link:hover,
 .c-block__media:hover + .c-block__object .c-block__title-link,
 .c-block__media:hover .c-block__title-link {
   color: rgb(var(--color-link-hover));
@@ -31,6 +32,20 @@
 
 .c-block__title {
   @include typeface(header, 10);
+  @include media(">medium") {
+    @include typeface(header, 8);
+  }
+  line-height: var(--line-height-4);
+
+  a,
+  a:visited,
+  a:active {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }
 
 .c-block__title--has-icon a:after {
@@ -154,7 +169,18 @@
 
 .c-block--horizontal--large .c-block__title {
   @include media(">medium") {
-    @include typeface(header, 11);
+    @include typeface(header, 8);
+  }
+  line-height: var(--line-height-4);
+
+  a,
+  a:visited,
+  a:active {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }
 
@@ -176,7 +202,7 @@
 }
 
 .c-block-meta__timestamp {
-  @include typeface(small, 1);
+  @include typeface(small, 2);
   text-transform: uppercase;
   font-weight: normal;
   vertical-align: middle;

--- a/app/styles/_library/_objects.forms.scss
+++ b/app/styles/_library/_objects.forms.scss
@@ -125,7 +125,7 @@ div.o-confirm-message p {
 }
 
 .c-search--top .c-search__button:hover {
-  background-color: rgb(var(--color-primary-1));
+  opacity: var(--opacity-hover);
 }
 
 /* Top search entry is open*/
@@ -378,6 +378,10 @@ div.o-confirm-message p {
 
   .o-button {
     background-color: rgb(var(--color-form-button));
+
+    &:hover {
+      opacity: var(--opacity-hover);
+    }
   }
 
   input[type=checkbox] {

--- a/app/styles/_library/_objects.leads.scss
+++ b/app/styles/_library/_objects.leads.scss
@@ -85,7 +85,7 @@
   white-space: nowrap;
 }
 .c-lead-gallery__thumbs-thumb-text:hover {
-  background-color: rgb(var(--color-link-hover-background));
+  background-color: rgb(var(--color-link-hover));
 }
 .c-lead-gallery__thumbs-thumb-text span {
   display: block;

--- a/app/styles/_library/_objects.messaging.scss
+++ b/app/styles/_library/_objects.messaging.scss
@@ -34,7 +34,8 @@
 
 .o-box-banner__close {
   position: absolute;
-  right: var(--space-2);
+  right: var(--space-5);
+  top: 0;
 }
 
 .o-box-banner__title {

--- a/app/styles/_library/_objects.navs.scss
+++ b/app/styles/_library/_objects.navs.scss
@@ -179,6 +179,11 @@
 .c-primary-nav--side .c-primary-nav__link {
   font-size: 28px;
   line-height: 1;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 .c-primary-nav.c-primary-nav--top ul,
@@ -209,6 +214,11 @@
   margin-bottom: var(--space-2);
   line-height: 1;
   padding-bottom: var(--space-1);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 /**

--- a/app/styles/_library/_objects.sections.scss
+++ b/app/styles/_library/_objects.sections.scss
@@ -378,9 +378,6 @@
 }
 .c-basic__heading {
   @include typeface(header, 13);
-  @include media(">=medium") {
-    @include typeface(header, 15);
-  }
 }
 .c-basic__header-kicker {
   @include typeface(small, 1);

--- a/app/styles/_library/_objects.sections.scss
+++ b/app/styles/_library/_objects.sections.scss
@@ -253,6 +253,7 @@
   }
 }
 .c-section__heading {
+  @include typeface(header, 12);
   font-weight: normal;
   letter-spacing: 3px;
 

--- a/app/styles/_library/_objects.sections.scss
+++ b/app/styles/_library/_objects.sections.scss
@@ -376,9 +376,9 @@
   }
 }
 .c-basic__heading {
-  @include typeface(header, 14);
+  @include typeface(header, 13);
   @include media(">=medium") {
-    @include typeface(header, 16);
+    @include typeface(header, 15);
   }
 }
 .c-basic__header-kicker {

--- a/app/styles/_library/_objects.sections.scss
+++ b/app/styles/_library/_objects.sections.scss
@@ -253,31 +253,18 @@
   }
 }
 .c-section__heading {
-  @include typeface(header, 12);
-  font-weight: normal;
-  letter-spacing: 3px;
-
-  @include media(">medium") {
-    @include typeface(header, 14);
-    font-weight: normal;
-  }
-
+  @include typeface(header, 13);
 }
 
 /**
  * Tag listing header
  */
 .c-tag-listing__heading {
-  @include typeface(header, 10);
+  @include typeface(header, 13);
   display: inline-block;
-  font-weight: normal;
   margin: var(--space-2) 0;
   color: rgb(var(--color-text));
   text-transform: capitalize;
-
-  @include media(">medium") {
-    @include typeface(header, 14);
-  }
 }
 
 /**

--- a/app/styles/_library/_objects.text.scss
+++ b/app/styles/_library/_objects.text.scss
@@ -59,7 +59,7 @@
 .o-rte-text > ol li,
 .o-rte-text > ul li,
 .o-rte-text > p {
-  @include typeface(body, 6);
+  @include typeface(body, 5);
 }
 
 .o-rte-text a {
@@ -86,8 +86,7 @@
 .o-rte-text > h4,
 .o-rte-text > h5,
 .o-rte-text > h6 {
-  padding-top: var(--space-3);
-  /*font-weight: normal;*/
+  padding-top: var(--space-4);
 }
 
 .o-rte-text > h1 {
@@ -182,13 +181,13 @@
   top: .75em;
   width: 7px;
   height: 7px;
-  background-color: rgb(var(--color-brick-red));
+  background-color: rgb(var(--color-text));
   border-radius: 50%;
 }
 
 .o-rte-text > ul li li:before {
   background-color: transparent;
-  border: 2px solid rgb(var(--color-brick-red));
+  border: 2px solid rgb(var(--color-text));
   width: 4px;
   height: 4px;
 }
@@ -414,7 +413,7 @@ a.o-breadcrumb:hover {
 /* Temporary until i can get the real icon*/
 .o-to-top .o-icon--up-arrow {
   margin-right: var(--space-2);
-  fill: rgb(var(--color-primary-2));
+  fill: rgb(var(--color-link));
 }
 
 .o-to-top svg {
@@ -422,7 +421,7 @@ a.o-breadcrumb:hover {
 }
 
 .o-to-top:hover {
-  color: rgb(var(--color-primary-2));
+  color: rgb(var(--color-link));
 }
 
 .o-to-top:hover .o-icon--up-arrow {
@@ -520,6 +519,13 @@ a.o-breadcrumb:hover {
 /**
  * Border accents
  */
+.o-border-accent {
+  background-image: repeating-linear-gradient(to right, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%), repeating-linear-gradient(to right, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%), repeating-linear-gradient(to bottom, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%), repeating-linear-gradient(to bottom, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%);
+  background-position: left top, left bottom, left top, right top;
+  background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
+  background-size: 18px 2px, 18px 2px, 2px 18px, 2px 18px;
+}
+
 .u-border-accent {
   @include border-accent;
 }

--- a/app/styles/_library/_objects.text.scss
+++ b/app/styles/_library/_objects.text.scss
@@ -59,7 +59,7 @@
 .o-rte-text > ol li,
 .o-rte-text > ul li,
 .o-rte-text > p {
-  @include typeface(body, 5);
+  @include typeface(body, 6);
 }
 
 .o-rte-text a {

--- a/app/styles/nypr-design-system/objects/_toggle-box.scss
+++ b/app/styles/nypr-design-system/objects/_toggle-box.scss
@@ -13,7 +13,7 @@ $ember-basic-dropdown-content-z-index: 10000;
 .c-toggle-box__label:before {
   width: 0;
   height: 0;
-  background-color: transparent;
+  background-color: rgb(var(--color-white));
   transform: translateY(20px);
   border: 12px solid transparent;
   border-bottom-color: white;

--- a/app/styles/themes/gothamist/_theme.colors.scss
+++ b/app/styles/themes/gothamist/_theme.colors.scss
@@ -107,7 +107,7 @@
 
   /* Footer */
   --color-footer-text: var(--color-white);
-  --color-footer-link: var(--color-banana-yellow);
+  --color-footer-link: var(--color-white);
 }
 
 @mixin color-group-dark {
@@ -191,7 +191,7 @@
 
   /* Footer */
   --color-footer-text: var(--color-white);
-  --color-footer-link: var(--color-banana-yellow);
+  --color-footer-link: var(--color-white);
 }
 
 /*  Base */

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -7,6 +7,10 @@ blockquote {
   border: 1px solid rgb(var(--color-brown-grey));
 }
 
+blockquote {
+  @include border-accent(bottom, left);
+}
+
 .c-article__body blockquote {
   border: none;
 }

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -484,6 +484,7 @@ blockquote {
   @include typeface(tags, 10);
   color: rgb(var(--color-text-inverse));
   text-transform: lowercase;
+  font-weight: normal;
   padding: var(--space-2) var(--space-3);
   background-color: rgb(var(--color-tag-highlight)); //dark
 
@@ -499,6 +500,13 @@ blockquote {
 .c-section__heading {
   @include typeface(small, 10);
   text-transform: uppercase;
+  font-weight: normal;
+  letter-spacing: 3px;
+
+  @include media(">medium") {
+    @include typeface(header, 14);
+    font-weight: normal;
+  }
 }
 
 .c-basic__heading {

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -96,6 +96,11 @@ blockquote {
   }
 }
 
+.c-main-footer__terms-links a:hover {
+  background-color: rgb(var(--color-primary-2));
+  color: rgb(var(--color-link-hover-2));
+}
+
 .c-main-footer {
   @include color-group-dark;
 

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -623,3 +623,12 @@ blockquote {
 .c-search--top .c-search__button:hover {
   background-color: rgb(var(--color-primary-1));
 }
+
+.c-contact-tout {
+  padding: var(--space-4);
+  width: 100%;
+}
+
+.u-reversed-out:after {
+  background-color: rgb(var(--color-background));
+}

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -25,10 +25,23 @@ blockquote {
   }
 }
 
+.c-main-header__share .c-share-tools__link:hover path {
+  fill: rgb(var(--color-header-icon-hover));
+}
+
 .c-main-header__donate.o-button {
   &::before {
     border: 3px solid rgb(var(--color-header-button-background));
   }
+}
+
+// Back to top icon & text
+.o-to-top .o-icon--up-arrow {
+  fill: rgb(var(--color-primary-2));
+}
+
+.o-to-top:hover {
+  color: rgb(var(--color-primary-2));
 }
 
 // Header with full stacked logo
@@ -199,15 +212,24 @@ blockquote {
   text-decoration: none;
 }
 
+.c-block__object .c-block__title-link:hover,
 .c-block__title a:hover {
   color: rgb(var(--color-reddish-orange));
   text-decoration: underline;
   text-decoration-style: dotted;
 }
 
-// Homepage Featured Block
-.c-featured-blocks__heading {
-  @include typeface(header, 11);
+.c-block__title {
+  @include media(">medium") {
+    @include typeface(header, 10);
+  }
+}
+
+.c-block--horizontal--large .c-block__title {
+  @include media(">medium") {
+    font-size: var(--font-size-11);
+    line-height: var(--line-height-11);
+  }
 }
 
 // Top Navigation
@@ -216,6 +238,11 @@ blockquote {
 }
 
 // Side Navigaton
+.c-side-menu .c-search__button:hover {
+  background-color: rgb(var(--color-form-button));
+  opacity: 1;
+}
+
 .c-primary-nav--side .c-primary-nav__link {
   padding-bottom: 2px;
   color: rgb(var(--color-banana-yellow));
@@ -317,7 +344,7 @@ blockquote {
 }
 
 // footer newsletter signup
-footer .c-newsletter-form__terms a {
+.c-main-footer .c-newsletter-form__terms a {
   color: rgb(var(--color-text));
   border-bottom: 2px dotted rgb(var(--color-text));
 }
@@ -377,9 +404,33 @@ footer .c-newsletter-form__terms a {
   text-transform: uppercase;
 }
 
+// gallery
+
+.c-lead-gallery__thumbs-thumb-text:hover {
+  background-color: rgb(var(--color-link-hover-background));
+}
+
 // staff page
 .o-rte-text > h3 {
   font-weight: normal;
+}
+
+.o-rte-text > ul li:before {
+  background-color: rgb(var(--color-brick-red));
+}
+
+.o-rte-text > ul li li:before {
+  border: 2px solid rgb(var(--color-brick-red));
+}
+
+// article page
+
+.c-article__headline {
+  @include typeface(header, 14);
+
+  @include media(">medium") {
+    @include typeface(header, 16);
+  }
 }
 
 // article page image caption arrow icon
@@ -389,6 +440,14 @@ footer .c-newsletter-form__terms a {
 }
 
 // breaking news
+.c-block--urgent .c-block__title a {
+  &:hover {
+    color: rgb(var(--color-brick-red));
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+}
+
 .c-banners .o-box-banner {
   padding: var(--space-3) var(--space-4) var(--space-4);
 }
@@ -404,6 +463,10 @@ footer .c-newsletter-form__terms a {
 
 .c-block--urgent .c-block-meta__timestamp {
   color: rgb(var(--color-brick-red));
+}
+
+.c-block-meta__timestamp {
+  @include typeface(small, 1);
 }
 
 // Section page
@@ -426,6 +489,13 @@ footer .c-newsletter-form__terms a {
 .c-section__heading {
   @include typeface(small, 10);
   text-transform: uppercase;
+}
+
+.c-basic__heading {
+  @include typeface(header, 14);
+  @include media(">=medium") {
+    @include typeface(header, 16);
+  }
 }
 
 .c-basic__header:before {
@@ -519,4 +589,37 @@ footer .c-newsletter-form__terms a {
   left: -4px;
   top: calc(50% + 1px);
   @include border-accent;
+}
+
+// Typography
+
+.o-rte-text > dl dd,
+.o-rte-text > dl dt,
+.o-rte-text > ol li,
+.o-rte-text > ul li,
+.o-rte-text > p {
+  @include typeface(body, 6);
+}
+
+.o-rte-text > h1,
+.o-rte-text > h2,
+.o-rte-text > h3,
+.o-rte-text > h4,
+.o-rte-text > h5,
+.o-rte-text > h6 {
+  padding-top: var(--space-3);
+}
+
+.u-has-accent--secondary:hover path,
+.o-rte-text .u-has-accent--secondary:hover path {
+  fill: rgb(var(--color-background));
+}
+
+.o-box-banner__close {
+  right: var(--space-2);
+  top: var(--space-2);
+}
+
+.c-search--top .c-search__button:hover {
+  background-color: rgb(var(--color-primary-1));
 }

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -598,14 +598,6 @@ blockquote {
 
 // Typography
 
-.o-rte-text > dl dd,
-.o-rte-text > dl dt,
-.o-rte-text > ol li,
-.o-rte-text > ul li,
-.o-rte-text > p {
-  @include typeface(body, 6);
-}
-
 .o-rte-text > h1,
 .o-rte-text > h2,
 .o-rte-text > h3,

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -637,3 +637,7 @@ blockquote {
 .u-reversed-out:after {
   background-color: rgb(var(--color-background));
 }
+
+.c-block--horizontal .c-block__title {
+  @include typeface(header, 8);
+}

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -411,6 +411,11 @@ blockquote {
 
 // gallery
 
+.c-gallery-overlay .o-credit a:hover {
+  color: rgb(var(--color-gallery-link));
+  background-color: rgb(var(--color-gallery-link-hover));
+}
+
 .c-lead-gallery__thumbs-thumb-text:hover {
   background-color: rgb(var(--color-link-hover-background));
 }

--- a/app/styles/themes/white-label/_theme.overrides.scss
+++ b/app/styles/themes/white-label/_theme.overrides.scss
@@ -10,67 +10,13 @@
   }
 }
 
-// Header donate
-.c-main-header__donate.o-button {
-  font-size: var(--font-size-5);
-}
-
 // Header search
 .c-search--top .c-search__close path {
   fill: rgb(var(--color-ember-red));
 }
 
-.c-search--top .c-search__button:hover {
-  opacity: var(--opacity-hover);
-}
-
-// Header with full stacked logo
+// Header logo
 .c-main-header--emphasis {
-  .c-main-header__ad-unit {
-    padding-bottom: var(--space-2);
-
-    @include media('>medium') {
-      padding-bottom: 30px;
-    }
-  }
-
-  &:not(.out-of-viewport) .c-primary-nav--top {
-    @include media('>xxlarge') {
-      padding-left: 166px;
-    }
-  }
-
-  &:not(.out-of-viewport) .c-main-header__branding {
-    width: 110px;
-    position: relative;
-    bottom: calc(var(--space-3) * -1);
-    align-self: flex-bottom;
-    z-index: $z-index-heading-logo;
-    left: var(--space-2);
-    opacity: 1;
-    transition: var(--animation-duration-fast) var(--animation-easing-incoming); // used to be $hard-ease-in
-
-    @include media('>medium') {
-      width: 135px;
-      bottom: calc(var(--space-2) * -1);
-    }
-
-    @include media('>xlarge') {
-      left: calc(var(--grid-col-width) + var(--grid-gutter));
-    }
-
-    --xl-container: calc(var(--max-width-xl) + var(--space-5));
-    @include media('>xxlarge') {
-      position: absolute;
-      bottom: -43px;
-      left: calc(50% - var(--xl-container) / 2 + var(--space-5));
-    }
-  }
-
-  .gothamist-letters {
-    fill: rgb(var(--color-black));
-  }
-
   .gothamist-buildings {
     fill: rgb(var(--color-black));
   }
@@ -80,19 +26,6 @@
 .c-main-footer {
   background-image: rgb(var(--color-cool-white));
   background: rgb(var(--color-cool-white));
-  color: rgb(var(--color-black));
-
-  a,
-  a:visited,
-  a:active {
-    color: rgb(var(--color-ceramic-blue));
-    text-decoration: none;
-
-    &:hover {
-      color: rgb(var(--color-ceramic-blue));
-      text-decoration: none;
-    }
-  }
 
   .gothamist-letters {
     fill: rgb(var(--color-black));
@@ -103,96 +36,23 @@
   }
 
   .c-main-footer__signup svg {
-    fill: rgb(var(--color-white));
+    fill: rgb(var(--color-text-inverse));
   }
 
   .c-newsletter-form__text p,
   .c-newsletter-form__terms p {
-    color: rgb(var(--color-white));
+    color: rgb(var(--color-text-inverse));
   }
 
   .c-newsletter-form__terms-checkbox a,
   .c-newsletter-form__terms-checkbox a:visited,
   .c-newsletter-form__terms-checkbox a:active {
     background: transparent;
-    color: rgb(var(--color-white));
+    color: rgb(var(--color-text-inverse));
 
     &:hover {
-      color: rgb(var(--color-white));
+      color: rgb(var(--color-text-inverse));
     }
-  }
-}
-
-// Typography
-.c-basic__heading {
-  @include typeface(header, 13);
-  @include media(">=medium") {
-    @include typeface(header, 15);
-  }
-}
-
-.c-block__title,
-.c-block--horizontal--large .c-block__title {
-  @include media(">medium") {
-    @include typeface(header, 8);
-  }
-
-  a,
-  a:visited,
-  a:active {
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: none;
-    }
-  }
-}
-
-.o-rte-text > dl dd,
-.o-rte-text > dl dt,
-.o-rte-text > ol li,
-.o-rte-text > ul li,
-.o-rte-text > p {
-  @include typeface(body, 5);
-}
-
-.o-rte-text > h1,
-.o-rte-text > h2,
-.o-rte-text > h3,
-.o-rte-text > h4,
-.o-rte-text > h5,
-.o-rte-text > h6 {
-  padding-top: var(--space-4);
-}
-
-.c-block__dek p,
-.c-block__title,
-.c-block--horizontal--large .c-block__title {
-  line-height: 1.25;
-}
-
-.c-block-meta__timestamp {
-  @include typeface(small, 2);
-}
-
-// Standard repeating dashed border
-.o-border-accent {
-  background-image: repeating-linear-gradient(to right, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%), repeating-linear-gradient(to right, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%), repeating-linear-gradient(to bottom, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%), repeating-linear-gradient(to bottom, rgb(var(--color-black)) 0%, rgb(var(--color-black)) 44%, transparent 44%, transparent 100%);
-  background-position: left top, left bottom, left top, right top;
-  background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
-  background-size: 18px 2px, 18px 2px, 2px 18px, 2px 18px;
-}
-
-// View All Brands Toggle Box
-.c-toggle-box__label::before {
-  background-color: rgb(var(--color-white));
-}
-
-.c-nypr-nav__link {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: none;
   }
 }
 
@@ -202,71 +62,14 @@
   border-color: rgb(var(--color-concrete));
 }
 
-.c-side-menu .c-search__button:hover {
-  background-color: rgb(var(--color-button-primary));
-  opacity: var(--opacity-hover);
-}
-
-.c-share-tools__link:hover path {
-  fill: rgb(var(--color-navigation-link-hover));
-}
-
-.c-primary-nav--side .c-primary-nav__link {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-// Back to top icon & text
-.o-to-top .o-icon--up-arrow {
-  fill: rgb(var(--color-link));
-}
-
-.o-to-top:hover {
-  color: rgb(var(--color-link));
-}
-
-// article page
-
-.u-has-accent--secondary path {
-  transition: var(--animation-duration-fast);
-}
-
-.u-has-accent--secondary:hover path,
-.o-rte-text .u-has-accent--secondary:hover path {
-  fill: rgb(var(--color-link-hover));
-}
-
-.c-lead-gallery__thumbs-thumb-text:hover {
-  background-color: rgb(var(--color-link-hover));
-}
-
 .o-caption .o-icon--dashed-arrow {
   fill: rgb(var(--color-sky-blue));
-}
-
-.c-article__headline {
-  @include typeface(header, 13);
-
-  @include media(">medium") {
-    @include typeface(header, 13);
-  }
 }
 
 // Staff page
 
 .c-author-block__details-link:hover {
   color: rgb(var(--color-sky-blue));
-}
-
-// Home page
-
-.c-block__object .c-block__title-link:hover {
-  color: rgb(var(--color-link-hover));
-  text-decoration: var(--text-decoration-link-hover);
-  opacity: var(--opacity-link-hover);
 }
 
 // newsletter signup
@@ -286,7 +89,6 @@
 
   &:hover {
     background-color: rgb(var(--color-sky-blue));
-    opacity: var(--opacity-hover);
   }
 }
 
@@ -310,21 +112,6 @@
   fill: rgb(var(--color-ceramic-blue));
 }
 
-// Gallery overlay
-.c-gallery-overlay .o-back-to-link {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-.c-gallery-overlay .u-has-accent:hover,
-.c-gallery-overlay .o-rte-text .u-has-accent:hover {
-  background-color: transparent;
-  opacity: var(--opacity-hover);
-}
-
 // Banners
 
 .c-banners .o-box-banner {
@@ -338,4 +125,3 @@
 .c-block--urgent .c-block__eyebrow > .o-kicker {
   background: rgb(var(--color-ceramic-blue));
 }
-

--- a/app/styles/themes/white-label/_theme.overrides.scss
+++ b/app/styles/themes/white-label/_theme.overrides.scss
@@ -66,12 +66,6 @@
   fill: rgb(var(--color-sky-blue));
 }
 
-// Staff page
-
-.c-author-block__details-link:hover {
-  color: rgb(var(--color-sky-blue));
-}
-
 // newsletter signup
 
 .c-newsletter-form__inner {
@@ -110,18 +104,4 @@
 
 .c-donate-tout__graphic path {
   fill: rgb(var(--color-ceramic-blue));
-}
-
-// Banners
-
-.c-banners .o-box-banner {
-  background: rgb(var(--color-cool-white));
-}
-
-.o-box-banner__close {
-  right: var(--space-5);
-}
-
-.c-block--urgent .c-block__eyebrow > .o-kicker {
-  background: rgb(var(--color-ceramic-blue));
 }

--- a/app/styles/themes/white-label/_theme.overrides.scss
+++ b/app/styles/themes/white-label/_theme.overrides.scss
@@ -86,6 +86,10 @@
   }
 }
 
+.c-newsletter-form__graphic {
+  mix-blend-mode: normal;
+}
+
 .c-newsletter-form__graphic path {
   fill: rgb(var(--color-sky-blue));
 }


### PR DESCRIPTION
Hey Matt - I pulled out everything I could from white label overrides, and this PR also includes a link URL update which I did while in the middle of the other stuff.

The styles left in the override file are for

1) overriding highly Gothamist specific stuff like the Gothamist logo - which we could remove altogether if we tell design they shouldn't care about this

2) colors for variables that don’t exist that design said to use - I wasn't sure how best to implement some of these (e.g., they wanted cool-white for the header and footer background, but there’s no variable for these and it’s set to --color-background which is set to white not cool white). Also icon colors, for example, the search X icon they wanted to be ember red and that doesn't exist in Gothamist

3) newsletter signup overrides - since gothamist is more of a light theme whereas white label is more of a dark theme, so the 2 just didn’t work well together without white label demo being it’s own site apart from gothamist. Maybe we can handle this when we do the newsletter component

4) the first style block was not added by me so I left it

Let me know what you think.