### PR TITLE
DS-867 footer links and more

### DIFF
--- a/addon/templates/components/nypr-m-secondary-nav.hbs
+++ b/addon/templates/components/nypr-m-secondary-nav.hbs
@@ -15,7 +15,7 @@
         {{else}}
           {{#link-to
             params=item.route
-            class="c-secondary-nav__link u-font--secondary-style u-font--xs u-color--white u-has-accent u-has-accent--white"
+            class="c-secondary-nav__link"
             data-test-secondary-nav-link=i
           }}
             {{item.text}}

--- a/app/styles/_library/_base.links.scss
+++ b/app/styles/_library/_base.links.scss
@@ -4,12 +4,13 @@
 
 a {
   text-decoration: none;
-  color: var(--color-link);
+  color: rgb(var(--color-link));
   text-decoration: var(--text-decoration-link);
   transition: all var(--animation-duration-fast) var(--animation-easing-standard); //used to be ease-in-out
 }
+
 a:hover {
-  color: var(--color-link-hover);
+  color: rgb(var(--color-link-hover));
   text-decoration: var(--text-decoration-link-hover);
   opacity: var(--opacity-link-hover);
 }
@@ -50,12 +51,6 @@ a > span {
 .o-rte-text .u-has-accent--quaternary {
   color: rgb(var(--color-primary-1));
   border-bottom-color: rgb(var(--color-primary-1));
-}
-
-.u-has-accent--white,
-.o-rte-text .u-has-accent--white {
-  color: rgb(var(--color-background));
-  border-bottom-color: rgb(var(--color-link));
 }
 
 .u-has-accent--secondary,

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -48,6 +48,10 @@
   }
 }
 
+.c-block__title a {
+  color: rbg(var(--color-text));
+}
+
 .c-block__title--has-icon a:after {
   content: "";
   display: inline-block;

--- a/app/styles/_library/_objects.navs.scss
+++ b/app/styles/_library/_objects.navs.scss
@@ -6,7 +6,6 @@
 *  Nav Links
 */
 .c-primary-nav__link,
-.c-secondary-nav__link,
 .c-read-more-nav__link,
 .c-nypr-nav__link,
 .c-main-footer-links a,

--- a/app/styles/themes/white-label/_theme.colors.scss
+++ b/app/styles/themes/white-label/_theme.colors.scss
@@ -41,12 +41,12 @@
   --color-text-metadata:        var(--color-dark-gray);
 
   /* Links */
-  --color-link:                 var(--color-cool-blue);
+  --color-link:                 var(--color-ceramic-blue);
   --text-decoration-link:       underline;
-  --color-link-hover:           var(--color-sky-blue);
-  --color-link-hover-background: var(--color-white);
+  --color-link-hover:           var(--color-ceramic-blue);
+  --color-link-hover-background: none;
   --text-decoration-link-hover: underline;
-  --opacity-link-hover:         1;
+  --opacity-link-hover:         0.8;
 
   /* Navigation Links */
   --color-navigation-link:                 var(--color-black);


### PR DESCRIPTION
Some weird stuff going on here.

- remove legacy utility classes that aren't doing anything from the footer link markup
- remove accent--white utility class, it's not used anywhere where it's not redundant anyway
- remove white label override styles
- looking at the design it looks like footer links are treated with standard link styles, not nav link styles. updated some selectors to reflect that
- updated white label link tokens to match current values in figma (no link atoms in figma yet but the "link button" should be 1 to 1 with standard links.)
- found out that default link color tokens are not being applied(!) (colors not wrapped with rgb) and fixed that
- this fix might have effects elsewhere? did a change to the card/block titles to handle this there at least.