### PR TITLE
Klarocca/whitelabel vqa

### DIFF
--- a/app/styles/_library/_module.gallery.scss
+++ b/app/styles/_library/_module.gallery.scss
@@ -39,6 +39,11 @@
   }
 }
 
+.c-gallery-overlay .o-back-to-link .u-has-accent,
+.c-gallery-overlay .o-back-to-link .u-has-accent:visited {
+  color: rgb(var(--color-white));
+}
+
 .c-gallery-overlay .u-has-accent:hover,
 .c-gallery-overlay .o-rte-text .u-has-accent:hover {
   background-color: transparent;

--- a/app/styles/_library/_objects.sections.scss
+++ b/app/styles/_library/_objects.sections.scss
@@ -109,6 +109,7 @@
 }
 
 .c-banners .o-box-banner {
+  position: relative;
   margin-bottom: 50px;
 }
 

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -399,19 +399,23 @@ blockquote {
 
   &:hover {
     text-decoration: none;
+
+    .u-has-accent {
+      &:hover {
+        background-color: rgb(var(--color-link-hover-background));
+      }
+    }
   }
 }
 
-.c-gallery-overlay .u-has-accent,
-.c-gallery-overlay .u-has-accent:visited {
-  color: rgb(var(--color-background));
-
-  &:hover {
-    background-color: rgb(var(--color-link-hover-background));
-  }
-
+.c-gallery-overlay .o-back-to-link .u-has-accent,
+.c-gallery-overlay .o-back-to-link .u-has-accent:visited {
+  color: rgb(var(--color-white));
 }
 
+.c-gallery-overlay .u-has-accent:hover {
+  background-color: rgb(var(--color-link-hover-background));
+}
 // gallery share text
 .o-text-with-icon {
   text-transform: uppercase;

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -278,7 +278,8 @@ blockquote {
 }
 
 .c-side-menu__terms-links a,
-.c-main-footer__terms-links a {
+.c-main-footer__terms-links a,
+.c-main-footer__terms-links a:visited {
   color: rgb(var(--color-banana-yellow));
   text-decoration: none;
   text-transform: uppercase;

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -408,11 +408,6 @@ blockquote {
   }
 }
 
-.c-gallery-overlay .o-back-to-link .u-has-accent,
-.c-gallery-overlay .o-back-to-link .u-has-accent:visited {
-  color: rgb(var(--color-white));
-}
-
 .c-gallery-overlay .u-has-accent:hover {
   background-color: rgb(var(--color-link-hover-background));
 }

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -402,6 +402,16 @@ blockquote {
   }
 }
 
+.c-gallery-overlay .u-has-accent,
+.c-gallery-overlay .u-has-accent:visited {
+  color: rgb(var(--color-background));
+
+  &:hover {
+    background-color: rgb(var(--color-link-hover-background));
+  }
+
+}
+
 // gallery share text
 .o-text-with-icon {
   text-transform: uppercase;


### PR DESCRIPTION
FYI cole said that gallery title should be white on every theme, that's why I pulled it out of the gothamist overrides