### PR TITLE
WNYC-227 WNYC-3000 Stream Switcher style/functionality tweaks

### DIFF
--- a/addon/components/organism/stream-switcher/stream/component.js
+++ b/addon/components/organism/stream-switcher/stream/component.js
@@ -31,12 +31,12 @@ export default Component.extend({
     });
 
     if (this.nowPlaying.slug == this.stream.slug) {
-      return;
+      if (!(this.hifi.isPlaying || this.hifi.isLoading)) {
+        this.dj.play(this.stream.slug);
+      }
+    } else {
+      this.nowPlaying.setStreamSchedule(this.stream.slug);
+      this.dj.play(this.stream.slug);
     }
-
-    if (this.hifi.isPlaying || this.hifi.isLoading) {
-      this.hifi.pause();
-    }
-    this.nowPlaying.setStreamSchedule(this.stream.slug);
   },
 });

--- a/addon/components/organism/stream-switcher/stream/template.hbs
+++ b/addon/components/organism/stream-switcher/stream/template.hbs
@@ -6,6 +6,7 @@
   @stream={{stream.stream}}
   @show={{stream.liveAiring.show}}
 />
+<div class='stream-switcher-streams-stream-on-now'>on now</div>
 <div class='stream-switcher-streams-stream-show-title'>
   {{stream.liveAiring.showTitle}}
 </div>

--- a/app/styles/_library/components/_stream-switcher.scss
+++ b/app/styles/_library/components/_stream-switcher.scss
@@ -161,6 +161,14 @@
         width: 40px;
       }
 
+      .stream-switcher-streams-stream-on-now {
+        font-weight: 700;
+        margin-right: var(--space-2);
+        pointer-events: none;
+        text-transform: uppercase;
+        width: 60px;
+      }
+
       .stream-switcher-streams-stream-show-title {
         @include typeface(body, 4);
         color: rgb(var(--color-background));

--- a/app/styles/themes/white-label/_theme.overrides.scss
+++ b/app/styles/themes/white-label/_theme.overrides.scss
@@ -165,7 +165,8 @@
 
 .stream-switcher-streams-stream-show-title,
 .up-next .up-next-time,
-.stream-switcher-stations-label {
+.stream-switcher-stations-label,
+.stream-switcher-streams-stream-on-now {
   display: none;
 }
 

--- a/app/styles/themes/wnyc/_theme.overrides.scss
+++ b/app/styles/themes/wnyc/_theme.overrides.scss
@@ -325,10 +325,36 @@ a {
   }
 }
 
-.stream-switcher-streams-stream-show-title,
-.up-next .up-next-time,
 .stream-switcher-stations-label {
   display: none;
+}
+
+.stream-switcher .stream-switcher-streams .stream-switcher-streams-stream {
+  .up-next {
+    display: none;
+  }
+
+  .up-next .up-next-time {
+    display: none;
+  }
+
+
+  .stream-switcher-streams-stream-show-title {
+    line-height: unset;
+  }
+}
+
+.stream-switcher .stream-switcher-streams .stream-switcher-streams-stream.is-active {
+  .stream-switcher-streams-stream-on-now {
+    display: none;
+  }
+  .stream-switcher-streams-stream-show-title {
+    display: none;
+  }
+
+  .up-next {
+    display: flex;
+  }
 }
 
 .stream-switcher-streams-stream {


### PR DESCRIPTION
- Display currently playing metadata, instead of up next metadata, for non-active streams in the Stream Switcher
- Play non-active stream when it is tapped in the Stream Switcher