### PR TITLE
Fix syntax on a fastboot check

### DIFF
--- a/addon/helpers/can-change-volume.js
+++ b/addon/helpers/can-change-volume.js
@@ -4,7 +4,7 @@ import { helper } from '@ember/component/helper';
 // https://developer.apple.com/library/content/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html#//apple_ref/doc/uid/TP40009523-CH5-SW11
 
 export function canChangeVolume() {
-  if (document && document.createElement) {
+  if (typeof(document) !== 'undefined' && document.createElement) {
     let audio = document.createElement('audio');
     if (audio.volume !== undefined) {
       audio.volume = 0.99; //arbitrary value


### PR DESCRIPTION
you can't check for an undeclared and undefined object the way i was doing it before