### PR TITLE
Style updates for GOTH-33

### DIFF
--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -5,6 +5,7 @@
 /**
  * Standard block
  */
+
 .c-block__media {
   margin-bottom: var(--space-2);
   text-align: right;
@@ -14,6 +15,7 @@
 .c-block__media:hover + .c-block__object .c-block__title-link,
 .c-block__media:hover .c-block__title-link {
   color: rgb(var(--color-link-hover));
+  background-color: transparent;
   text-decoration: var(--text-decoration-link-hover);
   opacity: var(--opacity-link-hover);
 }

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -249,6 +249,7 @@
 
 .c-block-meta .c-block-meta__comments:hover {
   color: rgb(var(--color-primary-2));
+  background-color: transparent;
 }
 
 .c-block-meta .c-block-meta__comments:hover .o-icon--comment {

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -233,7 +233,7 @@
   text-transform: uppercase;
 }
 
-.c-block-meta__comments {
+.c-block-meta .c-block-meta__comments {
   vertical-align: middle;
   display: inline-flex;
   align-items: center;
@@ -247,15 +247,15 @@
   }
 }
 
-.c-block-meta__comments:hover {
+.c-block-meta .c-block-meta__comments:hover {
   color: rgb(var(--color-primary-2));
 }
 
-.c-block-meta__comments:hover .o-icon--comment {
+.c-block-meta .c-block-meta__comments:hover .o-icon--comment {
   fill: rgb(var(--color-primary-2));
 }
 
-.c-block-meta__comments .o-icon--comment {
+.c-block-meta .c-block-meta__comments .o-icon--comment {
   margin-right: var(--space-1);
   fill: rgb(var(--color-text-metadata));
 

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -49,6 +49,10 @@
   }
 }
 
+.c-block .o-kicker:not(:last-child) {
+  margin-right: var(--space-2);
+}
+
 .c-block a.o-kicker {
   color: rgb(var(--color-tag-text));
   text-decoration: none;

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -52,6 +52,9 @@
 
 .c-block a.o-kicker {
   text-decoration: none;
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 .c-block__title a {

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -51,8 +51,10 @@
 }
 
 .c-block a.o-kicker {
+  color: rgb(var(--color-tag-text)
   text-decoration: none;
   &:hover {
+    color: rgb(var(--color-link-hover));
     text-decoration: none;
   }
 }

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -50,6 +50,10 @@
   }
 }
 
+.c-block a.o-kicker {
+  text-decoration: none;
+}
+
 .c-block__title a {
   color: rbg(var(--color-text));
 }

--- a/app/styles/_library/_objects.blocks.scss
+++ b/app/styles/_library/_objects.blocks.scss
@@ -43,7 +43,6 @@
   a:visited,
   a:active {
     text-decoration: none;
-
     &:hover {
       text-decoration: none;
     }
@@ -51,7 +50,7 @@
 }
 
 .c-block a.o-kicker {
-  color: rgb(var(--color-tag-text)
+  color: rgb(var(--color-tag-text));
   text-decoration: none;
   &:hover {
     color: rgb(var(--color-link-hover));

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -773,6 +773,7 @@ form .o-button:hover {
   font-weight: normal;
   padding: var(--space-2) var(--space-3);
   background-color: rgb(var(--color-tag-highlight)); //dark
+  margin-bottom: 0;
 
   @include media(">medium") {
     @include typeface(tags, 14);

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -1048,10 +1048,6 @@ form .o-button:hover {
     order: 3;
   }
 
-  .c-article__body-spacer {
-    padding-top: var(--space-5);
-  }
-
   // force 4:3 ratio on images
   .o-figure__image .o-picture {
     position: relative;

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -1048,10 +1048,16 @@ form .o-button:hover {
     order: 3;
   }
 
-  .c-article__body-spacer:not(:first-child) {
+  .c-article__body-spacer {
     margin-top: var(--space-5);
     margin-bottom: var(--space-5);
   }
+
+  .c-article__body-spacer:first-child {
+    margin-top: var(--space-4);
+    margin-bottom: var(--space-4);
+  }
+
 
   // force 4:3 ratio on images
   .o-figure__image .o-picture {

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -1048,6 +1048,11 @@ form .o-button:hover {
     order: 3;
   }
 
+  .c-article__body-spacer:not(:first-child) {
+    margin-top: var(--space-5);
+    margin-bottom: var(--space-5);
+  }
+
   // force 4:3 ratio on images
   .o-figure__image .o-picture {
     position: relative;

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -1002,7 +1002,8 @@ form .o-button:hover {
 
 .c-main.tags-page {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+
 
   .c-tag-listing__image {
     height: 95px;

--- a/app/styles/themes/gothamist/_theme.overrides.scss
+++ b/app/styles/themes/gothamist/_theme.overrides.scss
@@ -1004,6 +1004,9 @@ form .o-button:hover {
   display: flex;
   flex-direction: column;
 
+  .tagpage-zone {
+    max-width: none;
+  }
 
   .c-tag-listing__image {
     height: 95px;


### PR DESCRIPTION
- Some updates to the block template, mostly defining things  explicitly that  were assumed to be inhereted, (for example setting a transparent background for links), so they don't get automatically overridden in other contexts (for example a block in a content collection, inside of an article could get polluted with article link styles if it didn't have styles defined)
- Some update to tag page layout and spacing